### PR TITLE
feat: property management cut, smart address input, suggested rent fi…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,13 @@ Catalogue.html   → saved properties
 - Write rules for yourself that prevent the same mistake
 - Ruthlessly iterate on these lessons until mistake rate drops
 - Review lessons at session start for relevant project context
+- **After every task:** scan the project root for empty or stray text files and delete them — keep the workspace clean
+
+### 8. GRASP/FRAT Parity Rule
+- **GRASP and FRAT are both part of PAT.** Any bug fix, formula change, or UX improvement requested for one module must be evaluated for applicability to the other — even if the user only mentions one.
+- They share `supabase-client.js` and `app.js` but have independent JS files (`grasp.js`, `frat.js`) and HTML files.
+- Goal: migrate to `computeAllGRASP()` and `computeAllFRAT()` as separate functions in `app.js`, each with their own independent calculation flow, so changes to one don't silently break the other.
+- Until that migration happens: whenever touching a calculation in `grasp.js`, explicitly check whether `frat.js` has the equivalent and whether it needs the same change.
 
 ### 4. Verification Before Done
 - Never mark a task complete without proving it works

--- a/FRAT.html
+++ b/FRAT.html
@@ -87,22 +87,16 @@
         <!-- 0) Property -->
         <div class="section-title">Property</div>
         <div class="input">
-          <label>Street Address</label>
-          <input type="text" id="addr-street" placeholder="Street address">
+          <label>Property Address</label>
+          <input type="text" id="fullAddress" placeholder="e.g., 11 Edgeworth Pl, New Brunswick, NJ 08901" autocomplete="street-address">
+          <span class="small" id="addressHint" style="display:none;color:var(--text-muted)">Format: Street, City, State ZIP</span>
         </div>
-        <div class="grid three">
-          <div class="input">
-            <label>City</label>
-            <input type="text" id="addr-city" placeholder="City">
-          </div>
-          <div class="input">
-            <label>State</label>
-            <input type="text" id="addr-state" placeholder="ST" maxlength="2">
-          </div>
-          <div class="input">
-            <label>ZIP</label>
-            <input type="text" id="addr-zip" placeholder="ZIP" maxlength="10">
-          </div>
+        <!-- Hidden fields — source of truth for save; populated by parseFullAddress() -->
+        <div style="display:none">
+          <input type="text" id="addr-street">
+          <input type="text" id="addr-city">
+          <input type="text" id="addr-state">
+          <input type="text" id="addr-zip">
         </div>
         <div class="input">
           <label>Listing URL</label>

--- a/GRASP.HTML
+++ b/GRASP.HTML
@@ -158,22 +158,16 @@
         <!-- ── 0. Property ────────────────────────────────────────────────── -->
         <div class="section-title">Property</div>
         <div class="input">
-          <label>Street Address</label>
-          <input type="text" id="addr-street" placeholder="Street address">
+          <label>Property Address</label>
+          <input type="text" id="fullAddress" placeholder="e.g., 11 Edgeworth Pl, New Brunswick, NJ 08901" autocomplete="street-address">
+          <span class="small" id="addressHint" style="display:none;color:var(--text-muted)">Format: Street, City, State ZIP</span>
         </div>
-        <div class="grid three">
-          <div class="input">
-            <label>City</label>
-            <input type="text" id="addr-city" placeholder="City">
-          </div>
-          <div class="input">
-            <label>State</label>
-            <input type="text" id="addr-state" placeholder="ST" maxlength="2">
-          </div>
-          <div class="input">
-            <label>ZIP</label>
-            <input type="text" id="addr-zip" placeholder="ZIP" maxlength="10">
-          </div>
+        <!-- Hidden fields — source of truth for save; populated by parseFullAddress() -->
+        <div style="display:none">
+          <input type="text" id="addr-street">
+          <input type="text" id="addr-city">
+          <input type="text" id="addr-state">
+          <input type="text" id="addr-zip">
         </div>
         <div class="input">
           <label>Listing URL</label>
@@ -272,6 +266,13 @@
           <div class="input" id="avgRentGroup">
             <label>Rent per Bedroom/Unit (Monthly) *</label>
             <input type="number" id="rentPerUnitMonthly" min="0" step="0.01" placeholder="e.g., 900">
+          </div>
+        </div>
+        <div class="grid two" style="margin-top:10px">
+          <div class="input">
+            <label>Property Management Cut (%)</label>
+            <input type="number" id="propertyManagementCut" min="0" max="100" step="0.1" value="10" placeholder="e.g., 10">
+            <span class="small" style="color:var(--text-muted)">Applied to gross rent — <span id="pmLabel">10</span>% withheld by property manager</span>
           </div>
         </div>
 

--- a/assets/app.js
+++ b/assets/app.js
@@ -207,12 +207,14 @@ function computeAll(input) {
     mortgageMonthly = denom !== 0 ? loanAmount * r / denom : 0;
   }
 
+  const propertyManagementCut = Math.min(1, Math.max(0, toNumber(input.propertyManagementCutPct ?? 10) / 100));
+
   const grossRentMonthly = units * rentPerUnitMonthly;
   const operatingExpensesMonthly = taxesMonthly + insuranceMonthly + hoaMonthly + miscMonthly;
   const ownershipCostMonthly = operatingExpensesMonthly + mortgageMonthly;
 
-  // 10% vacancy factor applied to gross rent (mirrors PAT 2.0 workbook)
-  const effectiveRentMonthly = grossRentMonthly * 0.90;
+  // Property management cut applied to gross rent
+  const effectiveRentMonthly = grossRentMonthly * (1 - propertyManagementCut);
   const noiAnnual = (effectiveRentMonthly - operatingExpensesMonthly) * 12;
   const annualCashFlow = (effectiveRentMonthly - ownershipCostMonthly) * 12;
   const totalInitialInvestment = downPayment + estImprovementCost + closingCosts;
@@ -245,15 +247,15 @@ function computeAll(input) {
 
   // Suggested rent / unit to hit targets
   function rentPerUnitForCoC(targetCoC) {
-    if (units <= 0) return NaN;
+    if (units <= 0 || propertyManagementCut >= 1) return NaN;
     const numer = targetCoC * totalInitialInvestment + 12 * (operatingExpensesMonthly + mortgageMonthly);
-    const denom = 12 * units;
+    const denom = 12 * units * (1 - propertyManagementCut);
     return denom > 0 ? numer / denom : NaN;
   }
   function rentPerUnitForCap(targetCap) {
-    if (units <= 0) return NaN;
+    if (units <= 0 || propertyManagementCut >= 1) return NaN;
     const numer = targetCap * propertyValue + 12 * operatingExpensesMonthly;
-    const denom = 12 * units;
+    const denom = 12 * units * (1 - propertyManagementCut);
     return denom > 0 ? numer / denom : NaN;
   }
 

--- a/assets/frat.js
+++ b/assets/frat.js
@@ -30,6 +30,8 @@ document.addEventListener("DOMContentLoaded", async () => {
   }
 
   const els = {
+    fullAddress:  document.getElementById("fullAddress"),
+    addressHint:  document.getElementById("addressHint"),
     addrStreet: document.getElementById("addr-street"),
     addrCity:   document.getElementById("addr-city"),
     addrState:  document.getElementById("addr-state"),
@@ -226,6 +228,10 @@ document.addEventListener("DOMContentLoaded", async () => {
     els.addrCity.value        = currentProperty?.city        ?? "";
     els.addrState.value       = currentProperty?.state       ?? "";
     els.addrZip.value         = currentProperty?.zip         ?? "";
+    if (els.fullAddress) {
+      els.fullAddress.value = assembleAddress({ street: currentProperty?.street ?? "", city: currentProperty?.city ?? "", state: currentProperty?.state ?? "", zip: currentProperty?.zip ?? "" });
+      if (els.addressHint) els.addressHint.style.display = "none";
+    }
     els.link.value            = currentProperty?.zillow_link ?? "";
     els.propertyValue.value   = inp.propertyValue  ?? "";
     els.percentDownPct.value  = inp.percentDownPct ?? "";
@@ -273,6 +279,10 @@ document.addEventListener("DOMContentLoaded", async () => {
     els.addrCity.value        = defaults.city   ?? "";
     els.addrState.value       = defaults.state  ?? "";
     els.addrZip.value         = defaults.zip    ?? "";
+    if (els.fullAddress) {
+      els.fullAddress.value = assembleAddress({ street: defaults.street ?? "", city: defaults.city ?? "", state: defaults.state ?? "", zip: defaults.zip ?? "" });
+      if (els.addressHint) els.addressHint.style.display = "none";
+    }
     els.link.value            = defaults.link   ?? "";
     els.propertyValue.value   = "";
     els.percentDownPct.value  = "";
@@ -441,11 +451,46 @@ document.addEventListener("DOMContentLoaded", async () => {
       : 'Enter property value and down % to calculate';
   }
 
+  function parseFullAddress(value) {
+    const parts = value.split(',');
+    if (parts.length < 2) return null;
+    const street = parts[0].trim();
+    const lastTokens = parts[parts.length - 1].trim().split(/\s+/);
+    const zip   = /^\d{5}(-\d{4})?$/.test(lastTokens[lastTokens.length - 1]) ? lastTokens[lastTokens.length - 1] : '';
+    const state = /^[A-Za-z]{2}$/.test(lastTokens[lastTokens.length - (zip ? 2 : 1)])
+      ? lastTokens[lastTokens.length - (zip ? 2 : 1)].toUpperCase()
+      : '';
+    const city  = parts.slice(1, -1).join(',').trim();
+    return { street, city, state, zip };
+  }
+
+  function assembleAddress({ street, city, state, zip }) {
+    const parts = [street, city, [state, zip].filter(Boolean).join(' ')].filter(Boolean);
+    return parts.join(', ');
+  }
+
+  function applyParsedAddress(parsed) {
+    if (!parsed) return;
+    if (parsed.street) els.addrStreet.value = parsed.street;
+    if (parsed.city)   els.addrCity.value   = parsed.city;
+    if (parsed.state)  els.addrState.value  = parsed.state;
+    if (parsed.zip)    els.addrZip.value    = parsed.zip;
+  }
+
   function setAddressReadonly(locked) {
-    [els.addrStreet, els.addrCity, els.addrState, els.addrZip].forEach(el => {
-      el.readOnly = locked;
-      el.style.opacity = locked ? "0.7" : "";
-      el.style.cursor  = locked ? "default" : "";
+    if (els.fullAddress) {
+      els.fullAddress.readOnly      = locked;
+      els.fullAddress.style.opacity = locked ? "0.7" : "";
+      els.fullAddress.style.cursor  = locked ? "default" : "";
+    }
+  }
+
+  if (els.fullAddress) {
+    els.fullAddress.addEventListener("input", () => {
+      const val = els.fullAddress.value;
+      const hasComma = val.includes(',');
+      if (els.addressHint) els.addressHint.style.display = (val.length > 3 && !hasComma) ? "block" : "none";
+      applyParsedAddress(parseFullAddress(val));
     });
   }
 
@@ -575,6 +620,10 @@ document.addEventListener("DOMContentLoaded", async () => {
     try {
       if (currentScenarioId) {
         await updateScenario(currentScenarioId, scenarioData);
+        if (currentPropertyId) {
+          await updatePropertyZillowLink(currentPropertyId, (els.link.value || "").trim() || null);
+          if (currentProperty) currentProperty.zillow_link = (els.link.value || "").trim() || null;
+        }
         showToast("Scenario saved.", "success");
         lastSavedSnapshot = JSON.stringify(collectForm());
         isDirty = false;

--- a/assets/grasp.js
+++ b/assets/grasp.js
@@ -27,6 +27,8 @@ document.addEventListener("DOMContentLoaded", async () => {
   const els = {
     scenarioName:        document.getElementById("scenarioName"),
     scenarioDescription: document.getElementById("scenarioDescription"),
+    fullAddress:         document.getElementById("fullAddress"),
+    addressHint:         document.getElementById("addressHint"),
     addrStreet:          document.getElementById("addr-street"),
     addrCity:            document.getElementById("addr-city"),
     addrState:           document.getElementById("addr-state"),
@@ -77,6 +79,10 @@ document.addEventListener("DOMContentLoaded", async () => {
   // Income Efficiency elements — declared here to avoid temporal dead zone errors
   const ieInput = document.getElementById("incomeEfficiency");
   const ieLabel = document.getElementById("ieLabel");
+
+  // Property Management Cut elements
+  const pmInput = document.getElementById("propertyManagementCut");
+  const pmLabel = document.getElementById("pmLabel");
 
   // ── Access check — investor read-only enforcement ────────────────────────────
   let readOnly = false;
@@ -202,6 +208,13 @@ document.addEventListener("DOMContentLoaded", async () => {
       if (ieLabel) ieLabel.textContent = ieVal;
     }
 
+    // Load per-property Property Management Cut from Supabase (already in currentProperty)
+    if (pmInput) {
+      const pmVal = String(currentProperty?.property_management_cut ?? 10);
+      pmInput.value = pmVal;
+      if (pmLabel) pmLabel.textContent = pmVal;
+    }
+
     if (allScenarios.length > 0 && !newScenario) {
       // Load the most recent scenario
       loadScenarioIntoForm(allScenarios[0]);
@@ -305,6 +318,17 @@ document.addEventListener("DOMContentLoaded", async () => {
       const val = ieInput.value || "80";
       ieLabel.textContent = val;
       if (currentPropertyId) updatePropertyIncomeEfficiency(currentPropertyId, parseInt(val, 10) || 80);
+      triggerCompute();
+    });
+  }
+
+  // Keep PM label in sync and persist per-property
+  if (pmInput && pmLabel) {
+    pmInput.addEventListener("input", () => {
+      const val = pmInput.value || "10";
+      pmLabel.textContent = val;
+      if (currentPropertyId) updatePropertyManagementCut(currentPropertyId, parseFloat(val) || 10);
+      triggerCompute();
     });
   }
 
@@ -345,19 +369,20 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     // Compute KPIs (computeAll expects taxesMonthly)
     const kpiResult = computeAll({
-      propertyValue:      inputs.propertyValue,
-      percentDownPct:     inputs.percentDownPct,
-      rateAprPct:         inputs.rateAprPct,
-      loanLengthYears:    inputs.loanLengthYears,
-      taxesMonthly:       inputs.taxesAnnual / 12,
-      insuranceMonthly:   inputs.insuranceMonthly,
-      hoaMonthly:         inputs.hoaMonthly,
-      estImprovementCost: inputs.estImprovementCost,
-      closingCosts:       inputs.closingCosts,
-      miscRateAnnual:     inputs.miscRateAnnual,
-      incomeEfficiencyPct: normalized.incomeEfficiencyPct,
-      bedroomsOrUnits:    normalized.bedroomsOrUnits,
-      rentPerUnitMonthly: normalized.rentPerUnitMonthly,
+      propertyValue:           inputs.propertyValue,
+      percentDownPct:          inputs.percentDownPct,
+      rateAprPct:              inputs.rateAprPct,
+      loanLengthYears:         inputs.loanLengthYears,
+      taxesMonthly:            inputs.taxesAnnual / 12,
+      insuranceMonthly:        inputs.insuranceMonthly,
+      hoaMonthly:              inputs.hoaMonthly,
+      estImprovementCost:      inputs.estImprovementCost,
+      closingCosts:            inputs.closingCosts,
+      miscRateAnnual:          inputs.miscRateAnnual,
+      incomeEfficiencyPct:     normalized.incomeEfficiencyPct,
+      propertyManagementCutPct: normalized.propertyManagementCutPct,
+      bedroomsOrUnits:         normalized.bedroomsOrUnits,
+      rentPerUnitMonthly:      normalized.rentPerUnitMonthly,
     });
 
     // Rename suggestedRentPerUnit → suggestedGrossRent for v2 schema
@@ -390,6 +415,10 @@ document.addEventListener("DOMContentLoaded", async () => {
     try {
       if (currentScenarioId) {
         await updateScenario(currentScenarioId, scenarioData);
+        if (currentPropertyId) {
+          await updatePropertyZillowLink(currentPropertyId, normalized.link.trim() || null);
+          if (currentProperty) currentProperty.zillow_link = normalized.link.trim() || null;
+        }
         showToast("Scenario updated.", "success");
       } else {
         if (!currentPropertyId) {
@@ -433,11 +462,48 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   // ── Form helpers ──────────────────────────────────────────────────────────────
 
+  function parseFullAddress(value) {
+    const parts = value.split(',');
+    if (parts.length < 2) return null; // not enough structure to parse
+    const street = parts[0].trim();
+    const lastTokens = parts[parts.length - 1].trim().split(/\s+/);
+    const zip   = /^\d{5}(-\d{4})?$/.test(lastTokens[lastTokens.length - 1]) ? lastTokens[lastTokens.length - 1] : '';
+    const state = /^[A-Za-z]{2}$/.test(lastTokens[lastTokens.length - (zip ? 2 : 1)])
+      ? lastTokens[lastTokens.length - (zip ? 2 : 1)].toUpperCase()
+      : '';
+    const city  = parts.slice(1, -1).join(',').trim();
+    return { street, city, state, zip };
+  }
+
+  function assembleAddress({ street, city, state, zip }) {
+    const parts = [street, city, [state, zip].filter(Boolean).join(' ')].filter(Boolean);
+    return parts.join(', ');
+  }
+
+  function applyParsedAddress(parsed) {
+    if (!parsed) return;
+    if (parsed.street) els.addrStreet.value = parsed.street;
+    if (parsed.city)   els.addrCity.value   = parsed.city;
+    if (parsed.state)  els.addrState.value  = parsed.state;
+    if (parsed.zip)    els.addrZip.value    = parsed.zip;
+  }
+
   function setAddressReadonly(locked) {
-    [els.addrStreet, els.addrCity, els.addrState, els.addrZip].forEach(el => {
-      el.readOnly = locked;
-      el.style.opacity = locked ? "0.7" : "";
-      el.style.cursor  = locked ? "default" : "";
+    if (els.fullAddress) {
+      els.fullAddress.readOnly  = locked;
+      els.fullAddress.style.opacity = locked ? "0.7" : "";
+      els.fullAddress.style.cursor  = locked ? "default" : "";
+    }
+  }
+
+  // Wire fullAddress input → parse → hidden fields + hint
+  if (els.fullAddress) {
+    els.fullAddress.addEventListener("input", () => {
+      const val = els.fullAddress.value;
+      const hasComma = val.includes(',');
+      if (els.addressHint) els.addressHint.style.display = (val.length > 3 && !hasComma) ? "block" : "none";
+      const parsed = parseFullAddress(val);
+      applyParsedAddress(parsed);
     });
   }
 
@@ -450,6 +516,10 @@ document.addEventListener("DOMContentLoaded", async () => {
     els.addrCity.value            = defaults.city   ?? "";
     els.addrState.value           = defaults.state  ?? "";
     els.addrZip.value             = defaults.zip    ?? "";
+    if (els.fullAddress) {
+      els.fullAddress.value = assembleAddress({ street: defaults.street ?? "", city: defaults.city ?? "", state: defaults.state ?? "", zip: defaults.zip ?? "" });
+      if (els.addressHint) els.addressHint.style.display = "none";
+    }
     els.link.value                = defaults.link   ?? "";
     els.propertyValue.value       = "";
     els.percentDownPct.value      = "";
@@ -494,6 +564,10 @@ document.addEventListener("DOMContentLoaded", async () => {
     els.addrCity.value            = currentProperty?.city        ?? "";
     els.addrState.value           = currentProperty?.state       ?? "";
     els.addrZip.value             = currentProperty?.zip         ?? "";
+    if (els.fullAddress) {
+      els.fullAddress.value = assembleAddress({ street: currentProperty?.street ?? "", city: currentProperty?.city ?? "", state: currentProperty?.state ?? "", zip: currentProperty?.zip ?? "" });
+      if (els.addressHint) els.addressHint.style.display = "none";
+    }
     els.link.value                = currentProperty?.zillow_link ?? "";
     els.propertyValue.value       = inp.propertyValue ?? "";
     els.percentDownPct.value      = inp.percentDownPct ?? "";
@@ -623,7 +697,8 @@ document.addEventListener("DOMContentLoaded", async () => {
       rentPerUnitMonthly = round2(total / beds);
     }
 
-    const miscRateDecimal = (parseFloat(els.miscRateAnnual.value) || 1) / 100;
+    const rawMiscRate = parseFloat(els.miscRateAnnual.value);
+    const miscRateDecimal = (isNaN(rawMiscRate) ? 1 : rawMiscRate) / 100;
 
     return {
       scenarioName:        els.scenarioName.value || "",
@@ -640,7 +715,8 @@ document.addEventListener("DOMContentLoaded", async () => {
       estImprovementCost:  parseFloat(els.estImprovementCost.value) || 0,
       closingCosts:                parseFloat(els.closingCosts.value) || 0,
       closingCostsIsAutoCalculated: els.closingCosts.dataset.autoCalc !== "false",
-      incomeEfficiencyPct:         parseFloat(document.getElementById("incomeEfficiency")?.value) || 80,
+      incomeEfficiencyPct:          parseFloat(document.getElementById("incomeEfficiency")?.value) || 80,
+      propertyManagementCutPct:     parseFloat(document.getElementById("propertyManagementCut")?.value) || 10,
       miscRateAnnual:      miscRateDecimal,
       taxesAnnual,
       insuranceMonthly,
@@ -655,18 +731,20 @@ document.addEventListener("DOMContentLoaded", async () => {
   function triggerCompute() {
     const f = collectFormNormalized();
     const kpi = computeAll({
-      propertyValue:      f.propertyValue,
-      percentDownPct:     f.percentDownPct,
-      rateAprPct:         f.rateAprPct,
-      loanLengthYears:    f.loanLengthYears,
-      taxesMonthly:       f.taxesAnnual / 12,
-      insuranceMonthly:   f.insuranceMonthly,
-      hoaMonthly:         f.hoaMonthly,
-      estImprovementCost: f.estImprovementCost,
-      closingCosts:       f.closingCosts,
-      incomeEfficiencyPct: f.incomeEfficiencyPct,
-      bedroomsOrUnits:    f.bedroomsOrUnits,
-      rentPerUnitMonthly: f.rentPerUnitMonthly,
+      propertyValue:           f.propertyValue,
+      percentDownPct:          f.percentDownPct,
+      rateAprPct:              f.rateAprPct,
+      loanLengthYears:         f.loanLengthYears,
+      taxesMonthly:            f.taxesAnnual / 12,
+      insuranceMonthly:        f.insuranceMonthly,
+      hoaMonthly:              f.hoaMonthly,
+      estImprovementCost:      f.estImprovementCost,
+      closingCosts:            f.closingCosts,
+      miscRateAnnual:          f.miscRateAnnual,
+      incomeEfficiencyPct:     f.incomeEfficiencyPct,
+      propertyManagementCutPct: f.propertyManagementCutPct,
+      bedroomsOrUnits:         f.bedroomsOrUnits,
+      rentPerUnitMonthly:      f.rentPerUnitMonthly,
     });
 
     renderKPIs(kpi);

--- a/assets/supabase-client.js
+++ b/assets/supabase-client.js
@@ -113,7 +113,7 @@ async function fetchApprovedPropertyIds() {
 async function fetchProperty(propertyId) {
   const { data, error } = await supabaseClient
     .from('properties')
-    .select('id, street, city, state, zip, zillow_link, income_efficiency')
+    .select('id, street, city, state, zip, zillow_link, income_efficiency, property_management_cut')
     .eq('id', propertyId)
     .single();
   if (error) { console.error('fetchProperty:', error.message); return null; }
@@ -126,6 +126,22 @@ async function updatePropertyIncomeEfficiency(propertyId, value) {
     .update({ income_efficiency: value })
     .eq('id', propertyId);
   if (error) { console.error('updatePropertyIncomeEfficiency:', error.message); }
+}
+
+async function updatePropertyManagementCut(propertyId, value) {
+  const { error } = await supabaseClient
+    .from('properties')
+    .update({ property_management_cut: value })
+    .eq('id', propertyId);
+  if (error) { console.error('updatePropertyManagementCut:', error.message); }
+}
+
+async function updatePropertyZillowLink(propertyId, link) {
+  const { error } = await supabaseClient
+    .from('properties')
+    .update({ zillow_link: link || null })
+    .eq('id', propertyId);
+  if (error) { console.error('updatePropertyZillowLink:', error.message); }
 }
 
 function formatAddress({ street, city, state, zip }) {
@@ -248,7 +264,7 @@ async function recomputeAllScenarios() {
   // Fetch all active GRASP scenarios with their property's income_efficiency in one query
   const { data: scenarios, error } = await supabaseClient
     .from('scenarios')
-    .select('id, inputs, computed, bedrooms_or_units, bedroom_details, calculate_per_bedroom, properties(income_efficiency)')
+    .select('id, inputs, computed, bedrooms_or_units, bedroom_details, calculate_per_bedroom, properties(income_efficiency, property_management_cut)')
     .eq('module', 'GRASP')
     .is('archived_at', null);
 
@@ -258,6 +274,7 @@ async function recomputeAllScenarios() {
   const updates = scenarios.map(s => {
     const inp = s.inputs || {};
     const incomeEfficiencyPct = s.properties?.income_efficiency ?? 80;
+    const propertyManagementCutPct = s.properties?.property_management_cut ?? 10;
     // inputs stores taxesAnnual; computeAll expects taxesMonthly
     const taxesMonthly = (inp.taxesAnnual ?? 0) / 12;
 
@@ -279,6 +296,7 @@ async function recomputeAllScenarios() {
       rentPerUnitMonthly,
       bedroomsOrUnits: s.bedrooms_or_units,
       incomeEfficiencyPct,
+      propertyManagementCutPct,
     });
     return {
       id: s.id,

--- a/migration/01_schema.sql
+++ b/migration/01_schema.sql
@@ -213,3 +213,6 @@ ALTER TABLE properties
 ALTER TABLE properties DROP CONSTRAINT IF EXISTS address_unique;
 ALTER TABLE properties ADD CONSTRAINT address_street_zip_unique UNIQUE (street, zip);
 ALTER TABLE properties DROP COLUMN IF EXISTS address;
+
+-- v2.3: Property management cut — percentage of gross rent taken by property manager (default 10%)
+ALTER TABLE properties ADD COLUMN IF NOT EXISTS property_management_cut NUMERIC DEFAULT 10;

--- a/migration/Formulas.md
+++ b/migration/Formulas.md
@@ -57,13 +57,13 @@ Total Realistic Rent (AH) = Bedrooms/Units (Z) × Rent per Unit (AE) = Z × AE
 
 Gross Rent Monthly = Total Realistic Rent (AH) = AH
 
-**CRITICAL — Vacancy Factor:** PAT 2.0 applies a 10% vacancy discount to gross rent before computing NOI, Cap Rate, AND Annual Cash Flow. All income-based metrics use effective rent.
+**PAT 3.0 — Property Management Cut replaces Vacancy Factor:** PAT 2.0 used a fixed 10% vacancy discount. PAT 3.0 replaces this with a per-property `property_management_cut` field (stored in `properties.property_management_cut`, default 10%). Vacancy factor as a separate concept no longer exists — the PM cut captures the same income reduction.
 
-Effective Rent Monthly = Gross Rent (AH) × 0.90
+Effective Rent Monthly = Gross Rent (AH) × (1 - propertyManagementCut)
 
-NOI Annual (AG) = (Effective Rent - Recurring Payments (S)) × 12 = (AH × 0.9 - S) × 12
+NOI Annual (AG) = (Effective Rent - Recurring Payments (S)) × 12
 
-Annual Cash Flow (AI) = (Effective Rent - Ownership Cost (Monthly)) × 12 = (AH × 0.9 - S - N) × 12
+Annual Cash Flow (AI) = (Effective Rent - Ownership Cost (Monthly)) × 12 = (Effective Rent - S - N) × 12
 
 Annual Mortgage Payments (AL) = Mortgage Payment (N) × 12 = N × 12
 


### PR DESCRIPTION
…x, zillow link persistence

- Replace hardcoded 10% vacancy factor with dynamic property_management_cut (per-property, default 10%)
  - DB migration: ALTER TABLE properties ADD COLUMN property_management_cut NUMERIC DEFAULT 10
  - computeAll uses (1 - propertyManagementCut) for effectiveRent and suggested rent denominators
  - Input field added to GRASP Core Income Drivers; wired to Supabase via updatePropertyManagementCut()
- Fix suggested rent targets not producing indicated KPIs (CoC/Cap Rate inverse formula missing PM cut factor)
- Fix zillow_link not persisting when saving existing scenarios (added updatePropertyZillowLink + call in both modules)
- Replace 4-field address entry with single smart paste field in GRASP and FRAT
  - parseFullAddress() splits Street, City, State ZIP; hidden fields remain save source of truth
  - Fix city parse fallback bug (state tokens were bleeding into city for 2-part addresses)
- Fix propertyManagementCutPct using ?? instead of || (NaN-safe default)
- Update Formulas.md: vacancy factor replaced by property management cut spec
- Add GRASP/FRAT parity rule to CLAUDE.md